### PR TITLE
Fix latex rendering in toc.

### DIFF
--- a/docs/css/extra.css
+++ b/docs/css/extra.css
@@ -10,3 +10,11 @@
   width:90%;
   margin: 0 auto;
 }
+
+.md-nav__link {
+  display: block;
+}
+
+.md-nav__link > * {
+  display: inline;
+}


### PR DESCRIPTION
This PR fixes #10 .

将 `.md-nav__link` 从 `flex` 调整为 `block`, 副作用待观察。

若无副作用，该 PR 可合入主线。